### PR TITLE
# do not merge # alpine base image, latest filebeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.idea/
 /.config
 /coverage/
 /InstalledFiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,25 @@
-FROM prima/filebeat:1
+FROM alpine:3.5
 
 MAINTAINER Moshe Eshel <moshe.eshel@kenshoo.com>
+
+ENV FILEBEAT_VERSION=5.4.0 \
+    FILEBEAT_SHA1=c6f56d1a938889ec9f5db7caea266597f625fcc1
+
+RUN mkdir -p /opt
+RUN apk update && apk add bash wget
+RUN   wget --no-check-certificate https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz -O /opt/filebeat.tar.gz
+RUN cd /opt  \
+    && echo "${FILEBEAT_SHA1}  filebeat.tar.gz" | sha1sum -c -  \
+    && tar xzvf filebeat.tar.gz  \
+    && cd filebeat-*  \
+    && cp filebeat /bin  \
+    && cd /opt  \
+    && rm -rf filebeat*  \
+    && apk del wget \
+    && rm -rf /tmp/* /var/cache/apk/*
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 RUN mkdir -p /etc/pki/tls/certs;
 
@@ -11,3 +30,4 @@ ADD files/COMODORSADomainValidationSecureServerCA.crt /etc/pki/tls/certs/
 ADD scripts/* /root/
 
 CMD ["/root/go.sh"]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Add filebeat as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- filebeat "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
@eyalstoler this comes after #1  - meaning once 1 is merged we need to run the build and create a numbered image version in the artifactory
Steps to DO:
- [X] Merge #1 
- [X] run release to get a numbered version
- [X] modify [line](https://github.com/kenshoo/microcosm/blob/master/microcosm/source_template/Dockerrun.aws.json.template#L65) to use the latest numbered version
- [X] merge this PR, and run the build
- [ ] test
    - [ ] prepare "old" env (verify logs are being output to logz.io)
    - [ ] Change [line](https://github.com/kenshoo/microcosm/blob/master/microcosm/source_template/filebeat.yml.template#L61) from `tls` to `ssl` (looks like the only breaking change between current microcosm filebeat v1.3.1 and v5.4.0 - see [here](https://www.elastic.co/guide/en/beats/libbeat/current/upgrading-1-to-5.html) ) - **on your local microcosm copy**
    - [ ] modify [line](https://github.com/kenshoo/microcosm/blob/master/microcosm/source_template/Dockerrun.aws.json.template#L65) to use the **new** latest numbered version (after merge and image build)
    - [ ] deploy some java service (like test-service),  in new env and existing pre-prepared env (from step 5.0), verify logs are still being outputed to logz.io
- [ ] if everything is good, push change to microcosm (use the latest filebeat)